### PR TITLE
Remove custom size in pd objects

### DIFF
--- a/counter.pd
+++ b/counter.pd
@@ -3,7 +3,7 @@
 #X obj 80 58 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
 -1;
 #X obj 167 93 + 1;
-#X floatatom 80 122 5 0 0 0 - - -, f 5;
+#X floatatom 80 122 5 0 0 0 - - -;
 #X obj 80 149 outlet;
 #X obj 80 93 float 0;
 #X connect 0 0 1 0;

--- a/test.pd
+++ b/test.pd
@@ -1,7 +1,7 @@
 #N canvas 469 177 450 300 10;
 #X obj 183 109 metro 1000;
 #X msg 183 79 1;
-#X floatatom 183 155 5 0 0 0 - - -, f 5;
+#X floatatom 183 155 5 0 0 0 - - -;
 #X obj 183 133 counter;
 #X connect 0 0 3 0;
 #X connect 1 0 0 0;


### PR DESCRIPTION
Should work fine now :)
But that's definitely a bug and I'll fix it now.
